### PR TITLE
minor fix for speakers photo size for devices

### DIFF
--- a/esummit master/assets/css/styles.css
+++ b/esummit master/assets/css/styles.css
@@ -230,9 +230,21 @@ html, body {
   background-color: #111111;
 }
 
+@media screen and (min-width: 500px){
+  .speaker-photo{
+    width: 500px !important;
+    height: auto;
+  }
+}
+
+@media screen and (max-width: 500px){
+  .speaker-photo{
+    width: 100% !important;
+    height: auto;
+  }
+}
+
 .speaker-photo{
-  width: 500px !important;
-  height: auto;
   display: block;
   margin-left: auto;
   margin-right: auto;


### PR DESCRIPTION
```
@media screen and (min-width: 500px){
  .speaker-photo{
    width: 500px !important;
    height: auto;
  }
}

@media screen and (max-width: 500px){
  .speaker-photo{
    width: 100% !important;
    height: auto;
  }
}
```
This is all you need for making sure that the images are viewed properly on different devices.

- IceCereal :unicorn: :maple_leaf: 